### PR TITLE
Add weekly summary attributes to dates.

### DIFF
--- a/app/helpers/pivottables_helper.rb
+++ b/app/helpers/pivottables_helper.rb
@@ -61,6 +61,14 @@ module PivottablesHelper
           formatted_issue[c.caption] = c.value_object(i).to_s
         elsif c.name.to_s == "subject"
           formatted_issue[c.caption] = strip_tags(column_content(c, i))
+	elsif c.name.to_s.end_with?("_date") ||
+	      (c.is_a?(QueryCustomFieldColumn) && c.custom_field.field_format == "date")
+	  formatted_issue[c.caption] = column_content(c, i)
+	  if column_content(c, i).to_s != ""
+	    formatted_issue[c.caption+"(U)"] = Date.parse(column_content(c, i)).strftime("%Y-W%U")
+	  else
+	    formatted_issue[c.caption+"(U)"] = ""
+	  end
         else
           formatted_issue[c.caption] = column_content(c, i)
         end


### PR DESCRIPTION
This adds one extra attribute to date fields, an attribute for week number.

Week number is calculated according to Ruby's strftime("%U"). Which is: 

> Week number of the year, starting with the first Sunday as the first day of the first week.

Week number attribute is prefixed by %Y for proper sorting.

For the nature of pivottable.js, the "missing" week numbers cannot be filled or padded. If you do not have any data for, say Week24, then column "2016-W24" will not be shown in the pivot table. "2016-W25" will immediately follow "2016-W23".


