### PR TITLE
Add missing labels for Journal event type 'issue-edit'

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,5 +4,5 @@ en:
   header: "Pivot Table"
   clear_all: "Clear all attributes"
   label_issue_note_plural: "Issue notes"
+  label_issue_edit_plural: "Issue status updated"
   label_issue_closed_plural: "Issue closed"
-

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -4,5 +4,5 @@ ja:
   header: "ピボット集計"
   clear_all: "全ての項目をクリア"
   label_issue_note_plural: "チケット編集"
+  label_issue_edit_plural: "ステータスの更新"
   label_issue_closed_plural: "チケット終了"
-


### PR DESCRIPTION
When the status of an issue was updated but not closed, the Journal event will have the type `issue-edit`. There was no label for the activity selectbox for that case (It showed `Translation missing: xxx.label_issue_edit_plural`)

In this pull request we added the labels for English and Japanese