### PR TITLE
Fix postgresql error of previous fix

### DIFF
--- a/app/controllers/pivottables_controller.rb
+++ b/app/controllers/pivottables_controller.rb
@@ -64,7 +64,7 @@ class PivottablesController < ApplicationController
 
       @issues = @query.issues(:include => [:assigned_to, :tracker, :priority, :category, :fixed_version],
                               :offset => 0,
-                              :order => "(SELECT NULL)",
+                              :order => "issues.id",
                               :limit => limit)
     end
   end


### PR DESCRIPTION
`:order => "(SELECT NULL)"` doesn't work in postgresql, and `:order => "(SELECT NULL::text)"` doesn't work in MySQL.

I have decided to go with `:order => "issues.id"`