### PR TITLE
Fix for Missing term error occurs in redmine trunk(4.2)

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6,3 +6,5 @@ en:
   label_issue_note_plural: "Issue notes"
   label_issue_edit_plural: "Issue status updated"
   label_issue_closed_plural: "Issue closed"
+  label_overall_activity: Overall activity
+  label_overall_spent_time: Overall spent time

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -5,3 +5,5 @@ es:
   clear_all: "Borrar todos los atributos"
   label_issue_note_plural: "Notas de la tarea"
   label_issue_closed_plural: "Tarea cerrada"
+  label_overall_activity: Actividad global
+  label_overall_spent_time: Tiempo total dedicado

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -6,3 +6,5 @@ ja:
   label_issue_note_plural: "チケット編集"
   label_issue_edit_plural: "ステータスの更新"
   label_issue_closed_plural: "チケット終了"
+  label_overall_activity: すべての活動
+  label_overall_spent_time: すべての作業時間

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -6,4 +6,5 @@ pl:
   label_issue_note_plural: "Komentarze do zgłoszenia"
   label_issue_closed_plural: "Zamknięte zgłoszenia"
   permission_view_pivottables: "Podgląd tabeli przestawnej"
-
+  label_overall_activity: "Ogólna aktywność"
+  label_overall_spent_time: "Przepracowany czas"

--- a/config/locales/pt-br.yml
+++ b/config/locales/pt-br.yml
@@ -5,3 +5,5 @@ pt-br:
   clear_all: "Limpar todos os filtros"
   label_issue_note_plural: "Notas da tarefa"
   label_issue_closed_plural: "Tarefa fechada"
+  label_overall_activity: Atividades gerais
+  label_overall_spent_time: Tempo gasto geral

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -4,3 +4,5 @@ tr:
   project_module_pivottables: "Pivot"
   header: "Pivot Tablo"
   clear_all: "Tercihleri Sıfırla"
+  label_overall_activity: Tum faaliyetler
+  label_overall_spent_time: Toplam harcanan zaman

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -6,4 +6,5 @@ zh:
   clear_all: "清除所有属性"
   label_issue_note_plural: "问题批注"
   label_issue_closed_plural: "问题已关闭"
-
+  label_overall_activity: "活动概览"
+  label_overall_spent_time: "总体耗时"


### PR DESCRIPTION
Thanks for the useful plugin.

When using pivottable plugin in redmine trunk(4.2), an error without term occurs on the project summary screen.

In Redmine Core, these terms were deleted from the term file.
https://redmine.org/issues/33342

> label_overall_activity: Overall activity
> label_overall_spent_time: Overall spent time

As a measure for the following tickets,
I copied the relevant terms from the language files of Redmine3.4
